### PR TITLE
Fix issue with api naming

### DIFF
--- a/lib/api_generator/services/base_create.rb
+++ b/lib/api_generator/services/base_create.rb
@@ -33,7 +33,7 @@ module ApiGenerator
       end
 
       def source_root
-        gemfather_lib_path = $LOAD_PATH.grep(/gemfather/).first
+        gemfather_lib_path = $LOAD_PATH.grep(/gems\/gemfather/).first
 
         return File.expand_path('../', gemfather_lib_path) if gemfather_lib_path
 


### PR DESCRIPTION
У меня возникла проблема с тем, что если добавить gemfather в название апи, то падает генерация
<img width="817" alt="Screenshot 2023-09-22 at 00 32 43" src="https://github.com/domclick/gemfather/assets/14095146/bfd6ea37-8778-402c-ade7-43fc5ef1790b">

Это связано с тем что локальный путь к моей апи находится выше в списке $LOAD_PATH
<img width="895" alt="Screenshot 2023-09-22 at 00 28 20" src="https://github.com/domclick/gemfather/assets/14095146/05c22de2-4edf-43dd-9c12-78d3e1d86f14">

С моим фиксом такая проблема больше не должна возникать
<img width="539" alt="Screenshot 2023-09-22 at 01 01 09" src="https://github.com/domclick/gemfather/assets/14095146/c737f640-0665-4f93-93e6-aae3ed014977">
