### PR TITLE
Use syntax for default values supported in newer versions of dry-configurable

### DIFF
--- a/lib/api_generator/client/config.rb
+++ b/lib/api_generator/client/config.rb
@@ -9,6 +9,7 @@ module ApiGenerator
       MAX_RETRIES = 3
       RETRY_INTERVAL = 1
       RETRY_BACKOFF_FACTOR = 1
+      CONNECTION_ERROR = ApiGenerator::Middleware::HttpErrors::ConnectionError
 
       # rubocop:disable Metrics/MethodLength
       def self.extended(klass)
@@ -16,7 +17,7 @@ module ApiGenerator
 
         klass.class_eval do
           setting :api_endpoint, reader: true
-          setting :user_agent, USER_AGENT, reader: true
+          setting :user_agent, default: USER_AGENT, reader: true
 
           setting :api_header, reader: true
           setting :api_token, reader: true
@@ -27,18 +28,14 @@ module ApiGenerator
           setting :ssl_verify, reader: true
           setting :ca_file, reader: true
 
-          setting :open_timeout, OPEN_TIMEOUT, reader: true
-          setting :read_timeout, READ_TIMEOUT, reader: true
-          setting :max_retries, MAX_RETRIES, reader: true
-          setting :retry_interval, RETRY_INTERVAL, reader: true
-          setting :retry_backoff_factor, RETRY_BACKOFF_FACTOR, reader: true
+          setting :open_timeout, default: OPEN_TIMEOUT, reader: true
+          setting :read_timeout, default: READ_TIMEOUT, reader: true
+          setting :max_retries, default: MAX_RETRIES, reader: true
+          setting :retry_interval, default: RETRY_INTERVAL, reader: true
+          setting :retry_backoff_factor, default: RETRY_BACKOFF_FACTOR, reader: true
           setting :logger, reader: true
 
-          setting :retriable_errors,
-                  [
-                    ApiGenerator::Middleware::HttpErrors::ConnectionError,
-                  ],
-                  reader: true
+          setting :retriable_errors, default: [CONNECTION_ERROR], reader: true
         end
       end
       # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
Поскольку в [гемспек файле](https://github.com/domclick/gemfather/blob/cd618ad270198fd7823562dcc57063eb912b87bd/gem_template/%25app_name%25.gemspec.tt) версия dry-configurable указана плавающей`'~> 0.11'`, то в мой демо проект поставилась версия `0.16.1`.
И это привело к тому что при инстанцировании клиента гема возникает ошибка
<img width="1215" alt="Screenshot 2023-09-22 at 17 54 43" src="https://github.com/domclick/gemfather/assets/14095146/88e73569-d057-4a20-b1e4-badd5b459ca2">

Дело в том что в версии [0.13.0](https://github.com/dry-rb/dry-configurable/blob/main/CHANGELOG.md#0130-2021-09-12) `dry-configurable` задепрекейтил использовавшийся синтаксис для default значений.

Тут я это исправил
<img width="1217" alt="Screenshot 2023-09-22 at 17 55 38" src="https://github.com/domclick/gemfather/assets/14095146/6760ad7b-14e9-4cef-813d-bdbad036fbc3">

Кстати этот синтаксис работает и в старших версиях `dry-configurable`
<img width="697" alt="Screenshot 2023-09-22 at 18 00 06" src="https://github.com/domclick/gemfather/assets/14095146/f3e373b9-d086-4a64-832b-1d8a3fd39505">



