### PR TITLE
Set restriciton on api names because ruby variables can start only with letters or _

### DIFF
--- a/lib/api_generator/services/gemfather.rb
+++ b/lib/api_generator/services/gemfather.rb
@@ -37,6 +37,7 @@ module ApiGenerator
       def check_app_name(app_name)
         raise(Thor::Error, 'APP_NAME is not provided') unless app_name
         raise(Thor::Error, "Folder #{app_name} name already exists") if Dir.exist?("./#{app_name}")
+        raise(Thor::Error, "Api name can start only with letter or _") if app_name.chr.match(/[a-zA-Z_]/).nil?
       end
 
       def setup_template_variables(app_name)


### PR DESCRIPTION
Словил такую ошибку когда пытался назвать апи с цифры
<img width="1423" alt="Screenshot 2023-09-23 at 17 35 59" src="https://github.com/domclick/gemfather/assets/14095146/f29a2659-78ea-40cf-b137-a8c8352f1d55">

И она возникла потому что генератор создает переменную начиная с цифры и руби ожидаемо ругается на это