### PR TITLE
Allow use all_remainging pagination method to load all pages

### DIFF
--- a/lib/api_generator/pagination/page_relation.rb
+++ b/lib/api_generator/pagination/page_relation.rb
@@ -10,7 +10,7 @@ class ApiGenerator::Pagination::PageRelation < ApiGenerator::Pagination::Relatio
   private
 
   def next_relation
-    expand(page: [options[:page].to_i, 1].max + 1)
+    expand(page: [options[:page].to_i, 0].max + 1)
   end
 
   def last_page?


### PR DESCRIPTION
This change allows to use all_remaining method from relation.rb the way it will load all pages.
[WIP] It requires test coverage I think.